### PR TITLE
fix shutdown crash on windows

### DIFF
--- a/Dev/Cpp/src/EffekseerSystem.h
+++ b/Dev/Cpp/src/EffekseerSystem.h
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/rendering_server.hpp>
 #include <Effekseer.h>
 #include "RendererGodot/EffekseerGodot.Renderer.h"
 #include "SoundGodot/EffekseerGodot.SoundPlayer.h"
@@ -103,6 +104,7 @@ public:
 	void complete_all_shader_loads();
 
 private:
+  void _free_shader_loader_resources(godot::RenderingServer*);
 	void _process_shader_loader();
 
 private:

--- a/Dev/Godot/addons/effekseer/src/EffekseerEditorMenu.gd
+++ b/Dev/Godot/addons/effekseer/src/EffekseerEditorMenu.gd
@@ -1,8 +1,8 @@
 extends Node
 
 var _editor_plugin: EditorPlugin = null
-var _editing_emitter_2d: EffekseerEmitter2D
-var _editing_emitter_3d: EffekseerEmitter3D
+var _editing_emitter_2d: EffekseerEmitter2D = null
+var _editing_emitter_3d: EffekseerEmitter3D = null
 var _playing_emitter_2d: Array[EffekseerEmitter2D] = []
 var _playing_emitter_3d: Array[EffekseerEmitter3D] = []
 var _editor_viewport_2d: Array[SubViewport] = []


### PR DESCRIPTION
Concernig https://github.com/effekseer/EffekseerForGodot4/issues/2#issuecomment-1672130188.  
I fixed the shutdown crash.

- Tested on windows with a completely empty project and the gdextension.
- Tested on windows with activated addon and no Effekseer elements.
- Tested on windows with activated addon and some Effekseer examples.

There are still dangling references after the gdextension was unloaded/ plugin removed from tree.